### PR TITLE
DLAVAlertView delegate methods are optional

### DIFF
--- a/DLAlertView/Classes/DLAVAlertView.h
+++ b/DLAlertView/Classes/DLAVAlertView.h
@@ -20,7 +20,7 @@ typedef NS_ENUM (NSUInteger, DLAVAlertViewStyle) {
 #pragma mark Delegate Protocol
 
 @protocol DLAVAlertViewDelegate <NSObject>
-
+@optional
 // Called when a button is clicked. The view will be automatically dismissed after this call returns
 - (void)alertView:(DLAVAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex;
 


### PR DESCRIPTION
Hi,

I was getting a lot of warnings due to missing protocol methods. Those methods that seem to be not required though. I added @optional to silence these warnings. Would you mind to pull this change in? 
