### PR TITLE
Uses available title/message width instead of alert view width

### DIFF
--- a/DLAlertView/Classes/DLAVAlertView.m
+++ b/DLAlertView/Classes/DLAVAlertView.m
@@ -1175,11 +1175,15 @@ static const CGFloat DLAVAlertViewAnimationDuration = 0.3;
 }
 
 - (CGFloat)titleHeight  {
-	return [[self class] optimalSizeForLabel:self.titleLabel inMaxSize:CGSizeMake([self alertWidth], CGFLOAT_MAX)].height;
+	DLAVTextControlMargins margins = self.theme.titleMargins;
+    CGFloat usableWidth = [self alertWidth] - margins.left - margins.right;
+	return [[self class] optimalSizeForLabel:self.titleLabel inMaxSize:CGSizeMake(usableWidth, CGFLOAT_MAX)].height;
 }
 
 - (CGFloat)messageHeight  {
-	return (self.messageLabel) ? [[self class] optimalSizeForLabel:self.messageLabel inMaxSize:CGSizeMake([self alertWidth], CGFLOAT_MAX)].height : 0.0;
+	DLAVTextControlMargins margins = self.theme.messageMargins;
+    CGFloat usableWidth = [self alertWidth] - margins.left - margins.right;
+	return (self.messageLabel) ? [[self class] optimalSizeForLabel:self.messageLabel inMaxSize:CGSizeMake(usableWidth, CGFLOAT_MAX)].height : 0.0;
 }
 
 - (CGFloat)contentViewHeight  {


### PR DESCRIPTION
This bugfix makes sure title/message height is calculated correctly. It wasn't taking margins into account before. That was causing text wrapping issues when text is too long for width with margins, but would fit in alert view without margins.
