### PR TITLE
Alert View height off when there is no title

### DIFF
--- a/DLAlertView/Classes/DLAVAlertView.m
+++ b/DLAlertView/Classes/DLAVAlertView.m
@@ -1125,8 +1125,10 @@ static const CGFloat DLAVAlertViewAnimationDuration = 0.3;
 	CGFloat height = 0.0;
 	
 	// Title height:
-    DLAVTextControlMargins titleMargins = theme.titleMargins;
-	height += titleMargins.top + [self titleHeight] + titleMargins.bottom;
+    if (self.title) {
+        DLAVTextControlMargins titleMargins = theme.titleMargins;
+        height += titleMargins.top + [self titleHeight] + titleMargins.bottom;
+    }
 	
 	// Message height:
 	if (self.message) {


### PR DESCRIPTION
- The alert view would be off by 20px when you do not supply a title to
  the alert view. Added in a check to make sure the alert view has set a
  title prior to adding in the height for the title label.
