### PR TITLE
Fix orientation changes on iOS 8.

### DIFF
--- a/DLAlertView/Classes/DLAVAlertView.m
+++ b/DLAlertView/Classes/DLAVAlertView.m
@@ -1324,9 +1324,9 @@ static const CGFloat DLAVAlertViewAnimationDuration = 0.3;
 + (CGRect)getScreenFrameForOrientation:(UIInterfaceOrientation)orientation {
 	UIScreen *screen = [UIScreen mainScreen];
 	CGRect fullScreenRect = screen.bounds;
-	
-	if ((orientation == UIInterfaceOrientationLandscapeRight) ||
-		(orientation == UIInterfaceOrientationLandscapeLeft)) {
+
+	BOOL iOS8 = [[UIDevice currentDevice] systemVersion].floatValue >= 8.0;
+	if (!iOS8 && UIInterfaceOrientationIsLandscape(orientation)) {
 		CGRect temp = CGRectZero;
 		temp.size.width = fullScreenRect.size.height;
 		temp.size.height = fullScreenRect.size.width;

--- a/DLAlertView/Classes/DLAVAlertViewController.m
+++ b/DLAlertView/Classes/DLAVAlertViewController.m
@@ -169,8 +169,9 @@
 
 - (CGRect)frameForOrientation:(UIInterfaceOrientation)orientation {
 	CGRect frame;
-	
-	if ((orientation == UIInterfaceOrientationLandscapeLeft) || (orientation == UIInterfaceOrientationLandscapeRight)) {
+
+	BOOL iOS8 = [[UIDevice currentDevice] systemVersion].floatValue >= 8.0;
+	if (!iOS8 && UIInterfaceOrientationIsLandscape(orientation)) {
 		CGRect bounds = [UIScreen mainScreen].bounds;
 		frame = CGRectMake(bounds.origin.x, bounds.origin.y, bounds.size.height, bounds.size.width);
 	} else {


### PR DESCRIPTION
On iOS 8 rotation is applied above the window, so flipping width and height is not needed.
