### PR TITLE
Fix for AlertView rotation in iOS 8 #28: Implementing viewWillTransitionToSize for iOS 8

### DIFF
--- a/DLAlertView/Classes/DLAVAlertViewController.m
+++ b/DLAlertView/Classes/DLAVAlertViewController.m
@@ -190,11 +190,7 @@
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
     [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    BOOL iOS8 = [[UIDevice currentDevice] systemVersion].floatValue >= 8.0;
-    if (!iOS8) {
-        // On iOS do not handle the new orientation on this methid, which is deprecated (use viewWillTransitionToSize)
-        [self updateFrameWithOrientation:toInterfaceOrientation];
-    }
+    [self updateFrameWithOrientation:toInterfaceOrientation];
 }
 
 


### PR DESCRIPTION
On iOS 8 willRotateToInterfaceOrientation is deprecated. This leads to having buttons that are not clickable anymore when the screen rotates.

viewWillTransitionToSize (iOS 8) solves that.
