### PR TITLE
fc bug that the message will not show completely when there is no title  

### DIFF
--- a/DLAlertView/Classes/DLAVAlertView.m
+++ b/DLAlertView/Classes/DLAVAlertView.m
@@ -1212,7 +1212,10 @@ static const CGFloat DLAVAlertViewAnimationDuration = 0.3;
 	
 	// Message height:
 	if (self.message) {
-		DLAVTextControlMargins messageMargins = theme.messageMargins;
+        DLAVTextControlMargins messageMargins = theme.messageMargins;
+        if (!self.title) {
+            messageMargins.top = theme.titleMargins.top;
+        }
 		height += messageMargins.top + [self messageHeight] + messageMargins.bottom;
 	}
 	


### PR DESCRIPTION
If set the title to be empty  and message is not empty, the message will not show completely.
the solution is that re-set the message margin top when the title is empty